### PR TITLE
roo: Fix several ReferenceErrors and typos

### DIFF
--- a/lib/roo.js
+++ b/lib/roo.js
@@ -12,6 +12,7 @@ var logger = require('koa-logger');
 var resolve = require('path').resolve;
 var extname = require('path').extname;
 var basename = require('path').basename;
+var assert = require('assert');
 
 /**
  * Export `Serve`
@@ -23,7 +24,7 @@ module.exports = Serve;
  * Production
  */
 
-production = process.env.NODE_ENV == 'production';
+var production = process.env.NODE_ENV == 'production';
 
 /**
  * Initialize `Serve`
@@ -66,7 +67,7 @@ Serve.prototype.favicon = function(path) {
 
 Serve.prototype.auth = function(user, pass) {
   var auth = require('koa-basic-auth');
-  app.use(auth({ name: user, pass: pass }));
+  this.app.use(auth({ name: user, pass: pass }));
   return this;
 };
 


### PR DESCRIPTION
This patch fixes some typos which case the application to crash in
nonrecoverable ways:
- a missing `var` for the `production` flag (nonfatal, but w/e)
- a ReferenceError in `.auth()`
- a ReferenceError in `.mount()`
