### PR TITLE
prevent crash in debug mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -480,6 +480,8 @@ methods.forEach(function(method) {
 
 function tracer(gen) {
   console.log('implement tracer!');
+
+  return gen;
 }
 
 /**


### PR DESCRIPTION
Hey,

when I call `DEBUG=* iojs index.js` in a `roo()` application I get following stack trace:

```
assert.js:89
  throw new assert.AssertionError({
        ^
AssertionError: app.use() requires a generator function
    at Application.app.use (/Users/bodokaiser/src/github.com/bodokaiser/iswmle/node_modules/roo/node_modules/koa/lib/application.js:100:5)
    at Roo.use (/Users/bodokaiser/src/github.com/bodokaiser/iswmle/node_modules/roo/index.js:222:20)
    at Object.<anonymous> (/Users/bodokaiser/src/github.com/bodokaiser/iswmle/lib/index.js:9:4)
    at Module._compile (module.js:430:26)
    at Object.Module._extensions..js (module.js:448:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:471:10)
    at startup (node.js:117:18)
    at node.js:948:3
```

I assume you just forgotten to return the wrapped generator middleware so I added this.
